### PR TITLE
Remove redundant argument in compiled task 4

### DIFF
--- a/tasks/4/rdataframe_compiled.cxx
+++ b/tasks/4/rdataframe_compiled.cxx
@@ -4,10 +4,10 @@
 void rdataframe() {
     ROOT::EnableImplicitMT();
     ROOT::RDataFrame df("Events", "root://eospublic.cern.ch//eos/root-eos/benchmark/Run2012B_SingleMu.root");
-    auto filter = [](const ROOT::RVec<float> & pt, const ROOT::RVec<float> & eta) {
+    auto filter = [](const ROOT::RVec<float> & pt) {
             return Sum(pt > 40) > 1;
     };
-    auto h = df.Filter(filter, {"Jet_pt", "Jet_eta"}, "More than one jet with pt > 40")
+    auto h = df.Filter(filter, {"Jet_pt"}, "More than one jet with pt > 40")
                .Histo1D<float>({"", ";MET (GeV);N_{Events}", 100, 0, 200}, "MET_pt");
 
     TCanvas c;


### PR DESCRIPTION
The compiled version of task 4 was taking `eta` as an argument, which was needed in the computation. It is also not present in the jitted version.