### PR TITLE
Remove warnings from different type comparisons

### DIFF
--- a/tasks/5/rdataframe_compiled.cxx
+++ b/tasks/5/rdataframe_compiled.cxx
@@ -10,7 +10,7 @@ auto compute_dimuon_masses(Vec<float> pt, Vec<float> eta, Vec<float> phi, Vec<fl
 {
     ROOT::RVec<float> masses;
     const auto c = ROOT::VecOps::Combinations(pt, 2);
-    for (auto i = 0; i < c[0].size(); i++) {
+    for (auto i = 0u; i < c[0].size(); i++) {
         const auto i1 = c[0][i];
         const auto i2 = c[1][i];
         if (charge[i1] == charge[i2]) continue;

--- a/tasks/5/rdataframe_jitted.C
+++ b/tasks/5/rdataframe_jitted.C
@@ -5,7 +5,7 @@ auto compute_dimuon_masses(Vec<float> pt, Vec<float> eta, Vec<float> phi, Vec<fl
 {
     ROOT::RVec<float> masses;
     const auto c = ROOT::VecOps::Combinations(pt, 2);
-    for (auto i = 0; i < c[0].size(); i++) {
+    for (auto i = 0u; i < c[0].size(); i++) {
         const auto i1 = c[0][i];
         const auto i2 = c[1][i];
         if (charge[i1] == charge[i2]) continue;

--- a/tasks/6/rdataframe_compiled.cxx
+++ b/tasks/6/rdataframe_compiled.cxx
@@ -12,7 +12,7 @@ ROOT::RVec<std::size_t> find_trijet(Vec<XYZTVector> jets) {
   float distance = 1e9;
   const auto top_mass = 172.5;
   std::size_t idx = 0;
-  for (auto i = 0; i < c[0].size(); i++) {
+  for (auto i = 0u; i < c[0].size(); i++) {
     auto p1 = jets[c[0][i]];
     auto p2 = jets[c[1][i]];
     auto p3 = jets[c[2][i]];

--- a/tasks/6/rdataframe_jitted.C
+++ b/tasks/6/rdataframe_jitted.C
@@ -7,7 +7,7 @@ ROOT::RVec<std::size_t> find_trijet(Vec<XYZTVector> jets) {
   float distance = 1e9;
   const auto top_mass = 172.5;
   std::size_t idx = 0;
-  for (auto i = 0; i < c[0].size(); i++) {
+  for (auto i = 0u; i < c[0].size(); i++) {
     auto p1 = jets[c[0][i]];
     auto p2 = jets[c[1][i]];
     auto p3 = jets[c[2][i]];

--- a/tasks/7/rdataframe_compiled.cxx
+++ b/tasks/7/rdataframe_compiled.cxx
@@ -19,7 +19,7 @@ ROOT::RVec<int> find_isolated_jets(Vec<float> eta1, Vec<float> phi1, Vec<float> 
     }
 
     const auto c = ROOT::VecOps::Combinations(eta1, eta2_ptcut);
-    for (auto i = 0; i < c[0].size(); i++) {
+    for (auto i = 0u; i < c[0].size(); i++) {
         const auto i1 = c[0][i];
         const auto i2 = c[1][i];
         const auto dr = ROOT::VecOps::DeltaR(eta1[i1], eta2_ptcut[i2], phi1[i1], phi2_ptcut[i2]);

--- a/tasks/7/rdataframe_jitted.C
+++ b/tasks/7/rdataframe_jitted.C
@@ -15,7 +15,7 @@ ROOT::RVec<int> find_isolated_jets(Vec<float> eta1, Vec<float> phi1, Vec<float> 
     }
 
     const auto c = ROOT::VecOps::Combinations(eta1, eta2_ptcut);
-    for (auto i = 0; i < c[0].size(); i++) {
+    for (auto i = 0u; i < c[0].size(); i++) {
         const auto i1 = c[0][i];
         const auto i2 = c[1][i];
         const auto dr = ROOT::VecOps::DeltaR(eta1[i1], eta2_ptcut[i2], phi1[i1], phi2_ptcut[i2]);

--- a/tasks/8/rdataframe_compiled.cxx
+++ b/tasks/8/rdataframe_compiled.cxx
@@ -18,7 +18,7 @@ unsigned int additional_lepton_idx(Vec<float> pt, Vec<float> eta, Vec<float> phi
         return ROOT::Math::PtEtaPhiMVector(pt[idx], eta[idx], phi[idx], mass[idx]);
     };
 
-    for (auto i = 0; i < c[0].size(); i++) {
+    for (auto i = 0u; i < c[0].size(); i++) {
         const auto i1 = c[0][i];
         const auto i2 = c[1][i];
         if (charge[i1] == charge[i2]) continue;
@@ -36,7 +36,7 @@ unsigned int additional_lepton_idx(Vec<float> pt, Vec<float> eta, Vec<float> phi
     if (best_i1 == -1) return lep_idx;
 
     float max_pt = -999;
-    for (auto i = 0; i < pt.size(); i++) {
+    for (auto i = 0; i < int(pt.size()); i++) {
         if (i != best_i1 && i != best_i2 && pt[i] > max_pt) {
             max_pt = pt[i];
             lep_idx = i;
@@ -68,7 +68,7 @@ void rdataframe() {
                        {"nMuon", "nElectron"})
                .Define("AdditionalLepton_idx", additional_lepton_idx,
                        {"Lepton_pt", "Lepton_eta", "Lepton_phi", "Lepton_mass", "Lepton_charge", "Lepton_flavour"})
-               .Filter([](unsigned int idx) { return idx != -999; }, {"AdditionalLepton_idx"}, "No valid lepton pair found.")
+               .Filter([](int idx) { return idx != -999; }, {"AdditionalLepton_idx"}, "No valid lepton pair found.")
                .Define("TransverseMass", transverseMass,
                        {"Lepton_pt", "Lepton_phi", "MET_pt", "MET_phi", "AdditionalLepton_idx"})
 

--- a/tasks/8/rdataframe_jitted.C
+++ b/tasks/8/rdataframe_jitted.C
@@ -13,7 +13,7 @@ unsigned int additional_lepton_idx(Vec<float> pt, Vec<float> eta, Vec<float> phi
         return ROOT::Math::PtEtaPhiMVector(pt[idx], eta[idx], phi[idx], mass[idx]);
     };
 
-    for (auto i = 0; i < c[0].size(); i++) {
+    for (auto i = 0u; i < c[0].size(); i++) {
         const auto i1 = c[0][i];
         const auto i2 = c[1][i];
         if (charge[i1] == charge[i2]) continue;
@@ -31,7 +31,7 @@ unsigned int additional_lepton_idx(Vec<float> pt, Vec<float> eta, Vec<float> phi
     if (best_i1 == -1) return lep_idx;
 
     float max_pt = -999;
-    for (auto i = 0; i < pt.size(); i++) {
+    for (auto i = 0; i < int(pt.size()); i++) {
         if (i != best_i1 && i != best_i2 && pt[i] > max_pt) {
             max_pt = pt[i];
             lep_idx = i;


### PR DESCRIPTION
Change the type of the indexes (from int) to unsigned int.
Only in task 8 some indexes remained int, because they are compared with
negative values.