### PR TITLE
Fix Task 8 types

### DIFF
--- a/tasks/8/rdataframe_compiled.cxx
+++ b/tasks/8/rdataframe_compiled.cxx
@@ -9,10 +9,9 @@ using FourVector = ROOT::Math::PtEtaPhiMVector;
 unsigned int additional_lepton_idx(Vec<float> pt, Vec<float> eta, Vec<float> phi, Vec<float> mass, Vec<int> charge, Vec<int> flavour)
 {
     const auto c = Combinations(pt, 2);
-    unsigned int lep_idx = -999;
     float best_mass = 99999;
-    int best_i1 = -1;
-    int best_i2 = -1;
+    unsigned int best_i1 = 99999;
+    unsigned int best_i2 = 99999;
     const auto z_mass = 91.2;
     const auto make_p4 = [&](std::size_t idx) {
         return ROOT::Math::PtEtaPhiMVector(pt[idx], eta[idx], phi[idx], mass[idx]);
@@ -23,9 +22,7 @@ unsigned int additional_lepton_idx(Vec<float> pt, Vec<float> eta, Vec<float> phi
         const auto i2 = c[1][i];
         if (charge[i1] == charge[i2]) continue;
         if (flavour[i1] != flavour[i2]) continue;
-        const auto p1 = make_p4(i1);
-        const auto p2 = make_p4(i2);
-        const auto tmp_mass = (p1 + p2).mass();
+        const auto tmp_mass = (make_p4(i1) + make_p4(i2)).mass();
         if (std::abs(tmp_mass - z_mass) < std::abs(best_mass - z_mass)) {
             best_mass = tmp_mass;
             best_i1 = i1;
@@ -33,10 +30,11 @@ unsigned int additional_lepton_idx(Vec<float> pt, Vec<float> eta, Vec<float> phi
         }
     }
 
-    if (best_i1 == -1) return lep_idx;
+    if (best_i1 == 99999) return 99999;
 
     float max_pt = -999;
-    for (auto i = 0; i < int(pt.size()); i++) {
+    unsigned int lep_idx = 99999;
+    for (auto i = 0u; i < pt.size(); i++) {
         if (i != best_i1 && i != best_i2 && pt[i] > max_pt) {
             max_pt = pt[i];
             lep_idx = i;
@@ -68,7 +66,7 @@ void rdataframe() {
                        {"nMuon", "nElectron"})
                .Define("AdditionalLepton_idx", additional_lepton_idx,
                        {"Lepton_pt", "Lepton_eta", "Lepton_phi", "Lepton_mass", "Lepton_charge", "Lepton_flavour"})
-               .Filter([](int idx) { return idx != -999; }, {"AdditionalLepton_idx"}, "No valid lepton pair found.")
+               .Filter([](unsigned int idx) { return idx != 99999; }, {"AdditionalLepton_idx"}, "No valid lepton pair found.")
                .Define("TransverseMass", transverseMass,
                        {"Lepton_pt", "Lepton_phi", "MET_pt", "MET_phi", "AdditionalLepton_idx"})
 

--- a/tasks/8/rdataframe_jitted.C
+++ b/tasks/8/rdataframe_jitted.C
@@ -4,10 +4,9 @@ using FourVector = ROOT::Math::PtEtaPhiMVector;
 unsigned int additional_lepton_idx(Vec<float> pt, Vec<float> eta, Vec<float> phi, Vec<float> mass, Vec<int> charge, Vec<int> flavour)
 {
     const auto c = Combinations(pt, 2);
-    unsigned int lep_idx = -999;
     float best_mass = 99999;
-    int best_i1 = -1;
-    int best_i2 = -1;
+    unsigned int best_i1 = 99999;
+    unsigned int best_i2 = 99999;
     const auto z_mass = 91.2;
     const auto make_p4 = [&](std::size_t idx) {
         return ROOT::Math::PtEtaPhiMVector(pt[idx], eta[idx], phi[idx], mass[idx]);
@@ -18,9 +17,7 @@ unsigned int additional_lepton_idx(Vec<float> pt, Vec<float> eta, Vec<float> phi
         const auto i2 = c[1][i];
         if (charge[i1] == charge[i2]) continue;
         if (flavour[i1] != flavour[i2]) continue;
-        const auto p1 = make_p4(i1);
-        const auto p2 = make_p4(i2);
-        const auto tmp_mass = (p1 + p2).mass();
+        const auto tmp_mass = (make_p4(i1) + make_p4(i2)).mass();
         if (std::abs(tmp_mass - z_mass) < std::abs(best_mass - z_mass)) {
             best_mass = tmp_mass;
             best_i1 = i1;
@@ -28,10 +25,11 @@ unsigned int additional_lepton_idx(Vec<float> pt, Vec<float> eta, Vec<float> phi
         }
     }
 
-    if (best_i1 == -1) return lep_idx;
+    if (best_i1 == 99999) return 99999;
 
     float max_pt = -999;
-    for (auto i = 0; i < int(pt.size()); i++) {
+    unsigned int lep_idx = 99999;
+    for (auto i = 0u; i < pt.size(); i++) {
         if (i != best_i1 && i != best_i2 && pt[i] > max_pt) {
             max_pt = pt[i];
             lep_idx = i;
@@ -54,7 +52,7 @@ void rdataframe_jitted() {
                .Define("Lepton_flavour", "Concatenate(ROOT::RVec<int>(nMuon, 0), ROOT::RVec<int>(nElectron, 1))")
                .Define("AdditionalLepton_idx", additional_lepton_idx,
                        {"Lepton_pt", "Lepton_eta", "Lepton_phi", "Lepton_mass", "Lepton_charge", "Lepton_flavour"})
-               .Filter("AdditionalLepton_idx != -999", "No valid lepton pair found.")
+               .Filter("AdditionalLepton_idx != 99999", "No valid lepton pair found.")
                .Define("TransverseMass",
                        "sqrt(2.0 * Lepton_pt[AdditionalLepton_idx] * MET_pt * (1.0 - cos(ROOT::VecOps::DeltaPhi(MET_phi, Lepton_phi[AdditionalLepton_idx]))))")
                .Histo1D({"", ";Transverse mass (GeV);N_{Events}", 100, 0, 200}, "TransverseMass");


### PR DESCRIPTION
The Filter on "AdditionalLepton_idx" must be of type unsigned int.
However, it is compared with `-999`.  `-999` is used as a `null` value, to
show that the index was never updated.
Solution proposed is to initiliaze the `lep_idx` to 99999 which is certainly
larger than the largest possible `pt.size()`. Moreover, `best_i1` and
`best_i2` are also initialized to 99999, for the same reason so that
they are unsigned int.